### PR TITLE
channel_reg bug fixes

### DIFF
--- a/src/abbott/__FRACTAL_MANIFEST__.json
+++ b/src/abbott/__FRACTAL_MANIFEST__.json
@@ -492,6 +492,11 @@
             "type": "string",
             "description": "Against which wavelength the registration was calculated."
           },
+          "level": {
+            "title": "Level",
+            "type": "integer",
+            "description": "Against which pyramid level the registration was calculated."
+          },
           "overwrite_input": {
             "default": true,
             "title": "Overwrite Input",
@@ -508,7 +513,8 @@
         "required": [
           "zarr_url",
           "roi_table",
-          "reference_wavelength"
+          "reference_wavelength",
+          "level"
         ],
         "type": "object",
         "title": "ApplyChannelRegistrationElastix"

--- a/tests/test_registration_workflow.py
+++ b/tests/test_registration_workflow.py
@@ -343,6 +343,7 @@ def test_channel_registration_workflow(test_data_dir):
         zarr_url=zarr_url,
         roi_table=roi_table,
         reference_wavelength=reference_wavelength,
+        level=level,
         overwrite_input=False,
     )
     new_zarr_url = f"{zarr_url}_channels_registered"
@@ -353,6 +354,7 @@ def test_channel_registration_workflow(test_data_dir):
         zarr_url=zarr_url,
         roi_table=roi_table,
         reference_wavelength=reference_wavelength,
+        level=level,
         overwrite_input=False,
         overwrite_output=True,
     )
@@ -361,6 +363,7 @@ def test_channel_registration_workflow(test_data_dir):
         zarr_url=zarr_url,
         roi_table=roi_table,
         reference_wavelength=reference_wavelength,
+        level=level,
         overwrite_input=True,
     )
 
@@ -387,6 +390,7 @@ def test_channel_registration_workflow_varying_levels(test_data_dir):
         zarr_url=zarr_url,
         roi_table=roi_table,
         reference_wavelength=reference_wavelength,
+        level=level,
         overwrite_input=False,
     )
     new_zarr_url = f"{zarr_url}_channels_registered"


### PR DESCRIPTION
The apply_channel_registration_elastix task had a bug (reference wavelength image was not copied) and now also requires level parameter input (as used during compute_channel_registration_elastix) task. 