### PR TITLE
Handle Elastix RuntimeError in compute registration elastix task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ source = "vcs"
 # https://hatch.pypa.io/latest/config/build/
 [tool.hatch.build.targets.wheel]
 packages = ["src/abbott"]
+include = [
+    "src/abbott/registration/params_identity_*.txt",
+]
 
 [tool.hatch.metadata]
 allow-direct-references = true # for warpfield build from github

--- a/src/abbott/__FRACTAL_MANIFEST__.json
+++ b/src/abbott/__FRACTAL_MANIFEST__.json
@@ -122,6 +122,12 @@
             "title": "Masking Label Name",
             "type": "string",
             "description": "Optional label for masking ROI e.g. `embryo`."
+          },
+          "skip_failed_rois": {
+            "default": true,
+            "title": "Skip Failed Rois",
+            "type": "boolean",
+            "description": "If `True`, ROIs that fail during registration will be skipped and the task will continue with the next ROI. An identity transformation will be written for the failed ROIs and a condition table will be added to the OME-Zarr listing the ROIs with issues."
           }
         },
         "required": [

--- a/src/abbott/registration/params_identity_2d.txt
+++ b/src/abbott/registration/params_identity_2d.txt
@@ -1,0 +1,22 @@
+(Transform "EulerTransform")
+(NumberOfParameters 3)
+(TransformParameters 0 0 0)
+
+(InitialTransformParametersFileName "NoInitialTransform")
+(HowToCombineTransforms "Compose")
+
+(UseDirectionCosines "true")
+(CenterOfRotationPoint 0 0)
+
+(ResampleInterpolator "FinalBSplineInterpolator")
+(Resampler "DefaultResampler")
+(FinalBSplineInterpolationOrder 1)
+
+(Index 0 0)
+(Spacing 1.0 1.0)
+(Size 1 1)
+(Origin 0.0 0.0)
+(Direction 1 0 0 1)
+
+(DefaultPixelValue 0)
+(ResultImageFormat "mhd")

--- a/src/abbott/registration/params_identity_3d.txt
+++ b/src/abbott/registration/params_identity_3d.txt
@@ -1,0 +1,20 @@
+(Transform "EulerTransform")
+(NumberOfParameters 6)
+(TransformParameters 0 0 0 0 0 0)
+(InitialTransformParametersFileName "NoInitialTransform")
+(HowToCombineTransforms "Compose")
+
+(UseDirectionCosines "true")
+(CenterOfRotationPoint 0 0 0)
+(ResampleInterpolator "FinalBSplineInterpolator")
+(Resampler "DefaultResampler")
+(FinalBSplineInterpolationOrder 1)
+
+(Index 0 0 0)
+(Spacing 1.0 1.0 1.0)
+(Size 1 1 1)
+(Origin 0.0 0.0 0.0)
+(Direction 1 0 0 0 1 0 0 0 1)
+
+(DefaultPixelValue 0)
+(ResultImageFormat "mhd")


### PR DESCRIPTION
Closes #73 

@rhornb Just FYI for you of a change I'll apply to the registration task. It can optionally (depending on the `skip_failed_rois` setting) skip ROIs that triggered an Elastix Runtime error (see #73 for the examples when I've seen this happening). It will then return an identity transform for that ROI and create a table that lists ROIs with issues (so that these ROIs can be discarded from analysis in the end).

Once this passes Github CI, I'll merge & make a release to test this on a large dataset