### PR TITLE
Fix new ome-zarr var not being initialised in `copy_labels=False` branch of apply registration tasks

### DIFF
--- a/src/abbott/fractal_tasks/apply_registration_elastix.py
+++ b/src/abbott/fractal_tasks/apply_registration_elastix.py
@@ -234,7 +234,7 @@ def apply_registration_elastix(
             or table.table_type() == "masking_roi_table"
         ):
             # Copy ROI tables from the reference acquisition
-            new_ome_zarr.add_table(table_name, table, overwrite=overwrite_input)
+            new_ome_zarr.add_table(table_name, table, overwrite=True)
         else:
             logger.warning(
                 f"{zarr_url} contained a table that is not a standard "
@@ -244,7 +244,7 @@ def apply_registration_elastix(
             new_ome_zarr.add_table(
                 table_name,
                 table,
-                overwrite=overwrite_input,
+                overwrite=True,
             )
 
     logger.info(

--- a/src/abbott/fractal_tasks/apply_registration_elastix.py
+++ b/src/abbott/fractal_tasks/apply_registration_elastix.py
@@ -197,13 +197,12 @@ def apply_registration_elastix(
     ####################
     # Process labels
     ####################
+    new_ome_zarr = open_ome_zarr_container(new_zarr_url)
 
     if copy_labels:
         logger.info(
             "Copying labels from the reference acquisition to the new " "acquisition."
         )
-
-        new_ome_zarr = open_ome_zarr_container(new_zarr_url)
 
         label_names = ome_zarr_ref.list_labels()
         for label_name in label_names:

--- a/src/abbott/fractal_tasks/apply_registration_warpfield.py
+++ b/src/abbott/fractal_tasks/apply_registration_warpfield.py
@@ -230,11 +230,12 @@ def apply_registration_warpfield(
     ####################
     # Process labels
     ####################
+    new_ome_zarr = open_ome_zarr_container(new_zarr_url)
+
     if copy_labels:
         logger.info(
             "Copying labels from the reference acquisition to the new acquisition."
         )
-        new_ome_zarr = open_ome_zarr_container(new_zarr_url)
 
         label_names = ome_zarr_ref.list_labels()
         for label_name in label_names:
@@ -266,14 +267,14 @@ def apply_registration_warpfield(
             or table.table_type() == "masking_roi_table"
         ):
             # Copy ROI tables from the reference acquisition
-            ome_zarr_new.add_table(table_name, table, overwrite=overwrite_input)
+            new_ome_zarr.add_table(table_name, table, overwrite=overwrite_input)
         else:
             logger.warning(
                 f"{zarr_url} contained a table that is not a standard "
                 "ROI table. The `Apply Registration Warpfield` task is "
                 "best used before additional e.g. feature tables are generated."
             )
-            ome_zarr_new.add_table(
+            new_ome_zarr.add_table(
                 table_name,
                 table,
                 overwrite=overwrite_input,

--- a/src/abbott/fractal_tasks/apply_registration_warpfield.py
+++ b/src/abbott/fractal_tasks/apply_registration_warpfield.py
@@ -267,7 +267,7 @@ def apply_registration_warpfield(
             or table.table_type() == "masking_roi_table"
         ):
             # Copy ROI tables from the reference acquisition
-            new_ome_zarr.add_table(table_name, table, overwrite=overwrite_input)
+            new_ome_zarr.add_table(table_name, table, overwrite=True)
         else:
             logger.warning(
                 f"{zarr_url} contained a table that is not a standard "
@@ -277,7 +277,7 @@ def apply_registration_warpfield(
             new_ome_zarr.add_table(
                 table_name,
                 table,
-                overwrite=overwrite_input,
+                overwrite=True,
             )
 
     logger.info(


### PR DESCRIPTION
@rhornb Discovered a tricky little bug for new OME-Zarr not being correctly initialised and thus the table copying failing (that also used the `new_ome_zarr` in its add_table call).

I also checked the elastix task and noticed that the copying of tables only works for the reference cycle there, because the variable used is otherwise defined in the `write_registered_zarr` function. Fixed that there as well now.